### PR TITLE
Allow matching multiple attachment types

### DIFF
--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -128,7 +128,7 @@ const withShareExtensionTarget: ConfigPlugin<ShareExtensionPluginProps> = (confi
             (${rules
               .map((x) => `ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.${x}"`)
               .join(' || ')})
-          ).@count == 1 \
+          ).@count >= 1 \
         ).@count == 1`
     }
 


### PR DESCRIPTION
When the `activationRule` is configured to be an array of attachment types, currently a share will only match if exactly one attachment type matches. This change makes it so that if _one or more_ of the attachment types match, the share extension can be used to share it.

The use case that came up for me is this: I have a share extension that is for bookmarking URLs. Safari shares web pages as type `public.url`. Feedly, and RSS reader, shares them as type `public.plain-text`. So I want to match both of those types, so I configure an `activationRule` of `["url", "plain-text"]`.

However, when you share a web page from Firefox, it includes two attachments: one of type `public.url` and one of type `public.plain-text`. With the code currently on `main`, the attachment will not match, because the number of matching attachments is not `== 1`, it's 2.

I've been able to work around this by takin the generated predicate string, adjusting the `== 1` to `>= 1`, and setting the `activationRule` to that predicate string instead of an array.

But for the sake of users in general I think it makes sense to make this change to the predicate string that is generated, so all users benefit from it. Aside from my specific case, matching on at least one attachment seems like the most intuitive default behavior. Because the share extension can execute logic, it can look at whether it received one or multiple matching attachment types and decide what to do about it, regardless of the combination.